### PR TITLE
Add configurable timeout to API config

### DIFF
--- a/src/config/api.rs
+++ b/src/config/api.rs
@@ -97,10 +97,12 @@ impl ApiConfig {
     }
 
     pub fn get_timeout(&self) -> Option<Duration> {
-        match self.timeout {
-            Some(t) if t > 0 => Some(Duration::from_secs(t.into())),
-            _ => None,
-        }
+        let seconds = match self.timeout {
+            Some(t) if t > 0 => Some(t),
+            Some(0) => None,
+            _ => Some(30),
+        };
+        seconds.map(|t| Duration::from_secs(t.into()))
     }
 
     pub(super) fn ollama() -> Self {

--- a/src/config/api.rs
+++ b/src/config/api.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::default::Default;
 use std::fmt::Debug;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::{collections::HashMap, time::Duration};
 
 use super::{prompt::Prompt, resolve_config_path};
 
@@ -64,6 +64,8 @@ pub struct ApiConfig {
     pub default_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u16>,
 }
 
 impl Default for ApiConfig {
@@ -94,6 +96,13 @@ impl ApiConfig {
             .unwrap_or_default()
     }
 
+    pub fn get_timeout(&self) -> Option<Duration> {
+        match self.timeout {
+            Some(t) if t > 0 => Some(Duration::from_secs(t.into())),
+            _ => None,
+        }
+    }
+
     pub(super) fn ollama() -> Self {
         ApiConfig {
             api_key_command: None,
@@ -101,6 +110,7 @@ impl ApiConfig {
             url: String::from("http://localhost:11434/api/chat"),
             default_model: Some(String::from("phi3")),
             version: None,
+            timeout: None,
         }
     }
 
@@ -111,6 +121,7 @@ impl ApiConfig {
             url: String::from("https://api.openai.com/v1/chat/completions"),
             default_model: Some(String::from("gpt-4")),
             version: None,
+            timeout: None,
         }
     }
 
@@ -121,6 +132,7 @@ impl ApiConfig {
             url: String::from("https://api.mistral.ai/v1/chat/completions"),
             default_model: Some(String::from("mistral-medium")),
             version: None,
+            timeout: None,
         }
     }
 
@@ -131,6 +143,7 @@ impl ApiConfig {
             url: String::from("https://api.groq.com/openai/v1/chat/completions"),
             default_model: Some(String::from("llama3-70b-8192")),
             version: None,
+            timeout: None,
         }
     }
 
@@ -141,6 +154,7 @@ impl ApiConfig {
             url: String::from("https://api.anthropic.com/v1/messages"),
             default_model: Some(String::from("claude-3-opus-20240229")),
             version: Some(String::from("2023-06-01")),
+            timeout: None,
         }
     }
 }

--- a/src/text/api_call.rs
+++ b/src/text/api_call.rs
@@ -37,7 +37,10 @@ pub fn post_prompt_and_get_answer(
     // currently not compatible with streams
     prompt.stream = Some(false);
 
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::blocking::Client::builder()
+        .timeout(api_config.get_timeout())
+        .build()
+        .expect("Unable to initialize HTTP client");
 
     let prompt_format = match prompt.api {
         Api::Ollama | Api::Openai | Api::Mistral | Api::Groq => {

--- a/src/text/api_call.rs
+++ b/src/text/api_call.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::request_schemas::{AnthropicPrompt, OpenAiPrompt};
 use super::response_schemas::{AnthropicResponse, OllamaResponse, OpenAiResponse};
 
@@ -38,7 +40,11 @@ pub fn post_prompt_and_get_answer(
     prompt.stream = Some(false);
 
     let client = reqwest::blocking::Client::builder()
-        .timeout(api_config.get_timeout())
+        .timeout(
+            api_config
+                .timeout_seconds
+                .map(|t| Duration::from_secs(t.into())),
+        )
         .build()
         .expect("Unable to initialize HTTP client");
 


### PR DESCRIPTION
I'm currently experimenting with ollama on a not too powerful laptop, so I stumbled upon #22 pretty quickly.
Seeing as I liked the simplicity of smartcat and the fact it's Rust based, I figured I'd try my hand at adding an optional timeout parameter.

I implemented the "timeout" field in ApiConfig, and made it optional. I also made it so the reqwest client is instantiated through its builder so that the timeout can be specified. It could also be passed on the individual request, but since that form doesn't take an Option as a parameter, I figured this would be a bit cleaner.

 Right now, the logic works as such:

- If it's passed as a positive integer, the timeout is set as the parameter's value in seconds
- If it's passed as zero, the timeout is disabled entirely
- If it's omitted, it defaults to the standard 30 seconds