### PR TITLE
Support Azure OpenAI Service

### DIFF
--- a/src/config/api.rs
+++ b/src/config/api.rs
@@ -142,7 +142,7 @@ impl ApiConfig {
             url: String::from("https://your-azure-endpoint.azure.com/openai/deployments/your-deployment-id/chat/completions?api-version=2024-06-01"),
             default_model: Some(String::from("gpt-4o")),
             version: None,
-            timeout_seconds: Some(180),
+            timeout_seconds: None,
         }
     }
 

--- a/src/config/api.rs
+++ b/src/config/api.rs
@@ -20,6 +20,7 @@ pub enum Api {
     Groq,
     Mistral,
     Openai,
+    AzureOpenai,
 }
 
 impl FromStr for Api {
@@ -29,6 +30,7 @@ impl FromStr for Api {
         match s.to_lowercase().as_str() {
             "ollama" => Ok(Api::Ollama),
             "openai" => Ok(Api::Openai),
+            "azureopenai" => Ok(Api::AzureOpenai),
             "mistral" => Ok(Api::Mistral),
             "groq" => Ok(Api::Groq),
             "anthropic" => Ok(Api::Anthropic),
@@ -42,6 +44,7 @@ impl ToString for Api {
         match self {
             Api::Ollama => "ollama".to_string(),
             Api::Openai => "openai".to_string(),
+            Api::AzureOpenai => "azureopenai".to_string(),
             Api::Mistral => "mistral".to_string(),
             Api::Groq => "groq".to_string(),
             Api::Anthropic => "anthropic".to_string(),
@@ -132,6 +135,17 @@ impl ApiConfig {
         }
     }
 
+    pub(super) fn azureopenai() -> Self {
+        ApiConfig {
+            api_key_command: None,
+            api_key: None,
+            url: String::from("https://your-azure-endpoint.azure.com/openai/deployments/your-deployment-id/chat/completions?api-version=2024-06-01"),
+            default_model: Some(String::from("gpt-4o")),
+            version: None,
+            timeout_seconds: Some(180),
+        }
+    }
+
     pub(super) fn mistral() -> Self {
         ApiConfig {
             api_key_command: None,
@@ -174,6 +188,7 @@ pub(super) fn generate_api_keys_file() -> std::io::Result<()> {
     let mut api_config = HashMap::new();
     api_config.insert(Api::Ollama.to_string(), ApiConfig::ollama());
     api_config.insert(Api::Openai.to_string(), ApiConfig::openai());
+    api_config.insert(Api::AzureOpenai.to_string(), ApiConfig::azureopenai());
     api_config.insert(Api::Mistral.to_string(), ApiConfig::mistral());
     api_config.insert(Api::Groq.to_string(), ApiConfig::groq());
     api_config.insert(Api::Anthropic.to_string(), ApiConfig::anthropic());

--- a/src/text/api_call.rs
+++ b/src/text/api_call.rs
@@ -49,7 +49,7 @@ pub fn post_prompt_and_get_answer(
         .expect("Unable to initialize HTTP client");
 
     let prompt_format = match prompt.api {
-        Api::Ollama | Api::Openai | Api::Mistral | Api::Groq => {
+        Api::Ollama | Api::Openai | Api::AzureOpenai | Api::Mistral | Api::Groq => {
             PromptFormat::OpenAi(OpenAiPrompt::from(prompt.clone()))
         }
         Api::Anthropic => PromptFormat::Anthropic(AnthropicPrompt::from(prompt.clone())),
@@ -67,6 +67,7 @@ pub fn post_prompt_and_get_answer(
             "Authorization",
             &format!("Bearer {}", &api_config.get_api_key()),
         ),
+        Api::AzureOpenai => request.header("api-key", &api_config.get_api_key()),
         Api::Anthropic => request
             .header("x-api-key", &api_config.get_api_key())
             .header(
@@ -80,7 +81,7 @@ pub fn post_prompt_and_get_answer(
 
     let response_text: String = match prompt.api {
         Api::Ollama => handle_api_response::<OllamaResponse>(request.send()?),
-        Api::Openai | Api::Mistral | Api::Groq => {
+        Api::Openai | Api::AzureOpenai | Api::Mistral | Api::Groq => {
             handle_api_response::<OpenAiResponse>(request.send()?)
         }
         Api::Anthropic => handle_api_response::<AnthropicResponse>(request.send()?),


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/ai-services/openai/reference

This has the same basic interface as OpenAI itself, but uses a different auth header.

I called then new version "AzureOpenai" rather than just "Azure" as Azure hosts other LLMs apart from OpenAI as well.

This works fine when the .api_configs.toml and prompts.toml are set to use it. However I did see weirdness when specifying the api on the commandline.

Even though the new strings are AzureOpenai and azureopenai everywhere, the commandline needs `--api azure-openai` with a hypen to select it. I'm guessing that this is from some default camel-case to kebab-case handling of AzureOpenai.