### PR TITLE
Clarify anthropic version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ url = "https://api.groq.com/openai/v1/chat/completions"
 api_key = "<yet_another_api_key>"
 url = "https://api.anthropic.com/v1/messages"
 default_model = "claude-3-opus-20240229"
-version = "2023-06-01"
+version = "2023-06-01" # anthropic API version, see https://docs.anthropic.com/en/api/versioning
 ```
 
 `prompts.toml`


### PR DESCRIPTION
I thought that `version` referred to the model version (which was a bit confusing), when it refers to the API version. This just tries to clarify that.

Thanks for making a really cool tool!